### PR TITLE
Try to fix GlassFish issue

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Cargo.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Cargo.java
@@ -121,7 +121,7 @@ public class Cargo implements Serializable {
     }
 
     public RouteSpecification getRouteSpecification() {
-        return routeSpecification;
+        return Objects.requireNonNullElse(this.routeSpecification, RouteSpecification.EMPTY);
     }
 
     /**

--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Delivery.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Delivery.java
@@ -93,6 +93,9 @@ public record Delivery(
         Objects.requireNonNull(transportStatus, "Transport status is required");
         Objects.requireNonNull(routingStatus, "Routing status is required");
         Objects.requireNonNull(calculatedAt, "Calculated at is required");
+
+        // try to initialize nextExpectedActivity
+        nextExpectedActivity= Objects.requireNonNullElse(nextExpectedActivity, NO_ACTIVITY);
     }
 
     @Override

--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Delivery.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Delivery.java
@@ -82,7 +82,7 @@ public record Delivery(
     private static final long serialVersionUID = 1L;
 
     // Null object pattern.
-    public static final LocalDateTime ETA_UNKOWN = null;
+    public static final LocalDateTime ETA_UNKNOWN = null;
     // Null object pattern
     public static final HandlingActivity NO_ACTIVITY = HandlingActivity.EMPTY;
 

--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Delivery.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/Delivery.java
@@ -93,9 +93,6 @@ public record Delivery(
         Objects.requireNonNull(transportStatus, "Transport status is required");
         Objects.requireNonNull(routingStatus, "Routing status is required");
         Objects.requireNonNull(calculatedAt, "Calculated at is required");
-
-        // try to initialize nextExpectedActivity
-        nextExpectedActivity= Objects.requireNonNullElse(nextExpectedActivity, NO_ACTIVITY);
     }
 
     @Override

--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/DeliveryFactory.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/DeliveryFactory.java
@@ -108,7 +108,7 @@ public final class DeliveryFactory {
         if (onTrack(routingStatus, misdirected)) {
             return itinerary.getFinalArrivalDate();
         }
-        return Delivery.ETA_UNKOWN;
+        return Delivery.ETA_UNKNOWN;
     }
 
     static HandlingActivity calculateNextExpectedActivity(

--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/RouteSpecification.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/RouteSpecification.java
@@ -17,7 +17,6 @@ import java.util.Objects;
  */
 @Embeddable
 public record RouteSpecification(
-
         @ManyToOne
         @JoinColumn(name = "spec_origin_id")
         @NotNull
@@ -34,6 +33,9 @@ public record RouteSpecification(
 ) implements Specification<Itinerary>, Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    // Null object pattern.
+    public static final RouteSpecification EMPTY = new RouteSpecification(null, null, null);
 
     /**
      * Creates a new RouteSpecification with validation.

--- a/src/test/java/org/eclipse/cargotracker/application/BookingServiceIT.java
+++ b/src/test/java/org/eclipse/cargotracker/application/BookingServiceIT.java
@@ -170,7 +170,7 @@ public class BookingServiceIT {
             assertThat(cargo.getDelivery().lastKnownLocation()).isEqualTo(Location.UNKNOWN);
             assertThat(cargo.getDelivery().currentVoyage()).isEqualTo(Voyage.NONE);
             assertThat(cargo.getDelivery().misdirected()).isFalse();
-            assertThat(cargo.getDelivery().estimatedTimeOfArrival()).isEqualTo(Delivery.ETA_UNKOWN);
+            assertThat(cargo.getDelivery().estimatedTimeOfArrival()).isEqualTo(Delivery.ETA_UNKNOWN);
             assertThat(cargo.getDelivery().nextExpectedActivity()).isEqualTo(Delivery.NO_ACTIVITY);
             assertThat(cargo.getDelivery().unloadedAtDestination()).isFalse();
             assertThat(cargo.getDelivery().routingStatus()).isEqualTo(RoutingStatus.NOT_ROUTED);
@@ -238,7 +238,7 @@ public class BookingServiceIT {
             assertThat(cargo.getDelivery().lastKnownLocation()).isEqualTo(Location.UNKNOWN);
             assertThat(cargo.getDelivery().currentVoyage()).isEqualTo(Voyage.NONE);
             assertThat(cargo.getDelivery().misdirected()).isFalse();
-            assertThat(cargo.getDelivery().estimatedTimeOfArrival()).isEqualTo(Delivery.ETA_UNKOWN);
+            assertThat(cargo.getDelivery().estimatedTimeOfArrival()).isEqualTo(Delivery.ETA_UNKNOWN);
             assertThat(cargo.getDelivery().nextExpectedActivity()).isEqualTo(Delivery.NO_ACTIVITY);
             assertThat(cargo.getDelivery().unloadedAtDestination()).isFalse();
             assertThat(cargo.getDelivery().routingStatus()).isEqualTo(RoutingStatus.MISROUTED);
@@ -267,7 +267,7 @@ public class BookingServiceIT {
             assertThat(cargo.getDelivery().lastKnownLocation()).isEqualTo(Location.UNKNOWN);
             assertThat(cargo.getDelivery().currentVoyage()).isEqualTo(Voyage.NONE);
             assertThat(cargo.getDelivery().misdirected()).isFalse();
-            assertThat(cargo.getDelivery().estimatedTimeOfArrival()).isEqualTo(Delivery.ETA_UNKOWN);
+            assertThat(cargo.getDelivery().estimatedTimeOfArrival()).isEqualTo(Delivery.ETA_UNKNOWN);
             assertThat(cargo.getDelivery().nextExpectedActivity()).isEqualTo(Delivery.NO_ACTIVITY);
             assertThat(cargo.getDelivery().unloadedAtDestination()).isFalse();
             assertThat(cargo.getDelivery().routingStatus()).isEqualTo(RoutingStatus.MISROUTED);

--- a/src/test/java/org/eclipse/cargotracker/domain/model/cargo/DeliveryFactoryTest.java
+++ b/src/test/java/org/eclipse/cargotracker/domain/model/cargo/DeliveryFactoryTest.java
@@ -175,8 +175,8 @@ public class DeliveryFactoryTest {
         );
 
         assertThat(DeliveryFactory.calculateEta(itinerary, RoutingStatus.ROUTED, false)).isEqualTo(arrivalDate.truncatedTo(ChronoUnit.SECONDS));
-        assertThat(DeliveryFactory.calculateEta(itinerary, RoutingStatus.MISROUTED, false)).isEqualTo(Delivery.ETA_UNKOWN);
-        assertThat(DeliveryFactory.calculateEta(itinerary, RoutingStatus.ROUTED, true)).isEqualTo(Delivery.ETA_UNKOWN);
+        assertThat(DeliveryFactory.calculateEta(itinerary, RoutingStatus.MISROUTED, false)).isEqualTo(Delivery.ETA_UNKNOWN);
+        assertThat(DeliveryFactory.calculateEta(itinerary, RoutingStatus.ROUTED, true)).isEqualTo(Delivery.ETA_UNKNOWN);
     }
 
     @Test


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent potential null nextExpectedActivity in Delivery records by substituting a default NO_ACTIVITY value during construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “unknown ETA” value used during delivery ETA calculations and booking flows.
  * Ensured cargo route specifications always provide a non-null value to callers.
* **New Features**
  * Introduced a reusable empty route specification value for consistent “no data” handling.
* **Tests**
  * Updated integration and unit tests to reflect the corrected unknown-ETA constant usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->