### PR TITLE
Improve HandlingActivity with Null Object Pattern and compact constructor

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/domain/model/cargo/HandlingActivity.java
+++ b/src/main/java/org/eclipse/cargotracker/domain/model/cargo/HandlingActivity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import org.eclipse.cargotracker.domain.model.handling.HandlingEvent;
 import org.eclipse.cargotracker.domain.model.location.Location;
 import org.eclipse.cargotracker.domain.model.voyage.Voyage;
@@ -21,12 +22,12 @@ import java.util.Objects;
 public record HandlingActivity(
         @Enumerated(EnumType.STRING)
         @Column(name = "next_expected_handling_event_type")
-        //@NotNull(message = "Handling event type is required.")
+        @NotNull(message = "Handling event type is required.")
         HandlingEvent.Type type,
 
         @ManyToOne
         @JoinColumn(name = "next_expected_location_id")
-        //@NotNull(message = "Location is required.")
+        @NotNull(message = "Location is required.")
         Location location,
 
         @ManyToOne


### PR DESCRIPTION
Improve HandlingActivity record by adopting the Null Object Pattern and a compact constructor.

Changes:
- **HandlingActivity.EMPTY**: uses \HandlingEvent.Type.UNKNOWN\ and \Location.UNKNOWN\ instead of null values, consistent with the Null Object Pattern used elsewhere (\Voyage.NONE\, \Location.UNKNOWN\)
- **Compact constructor**: enforces non-null \	ype\ and \location\ at the record level
- **Static factory methods**: simplified — null checks moved into compact constructor
- **isEmpty()**: updated to use record equality against \EMPTY\ instead of null-field checks
- **Typo fix**: \UNKOWN\ → \UNKNOWN\ in \HandlingEvent.Type\ enum

Co-Authored-By: Oz <oz-agent@warp.dev>

## Summary by Sourcery

Adopt a Null Object-style sentinel for HandlingActivity and enforce non-null type and location via a compact record constructor.

New Features:
- Introduce HandlingActivity.EMPTY using HandlingEvent.Type.UNKNOWN and Location.UNKNOWN as a null-object sentinel value.
- Add UNKNOWN enum constant to HandlingEvent.Type as a sentinel for unknown handling types.

Enhancements:
- Enforce non-null handling event type and location in HandlingActivity via a compact constructor and Bean Validation annotations.
- Simplify HandlingActivity factory methods by centralizing null checks in the record constructor.
- Update HandlingActivity.isEmpty() to use equality against the EMPTY instance instead of null-field checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for handling events so required fields must now be provided.
  * Users will see clearer error messages when the event type or location is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->